### PR TITLE
chore: proposal of refactor method config handling

### DIFF
--- a/packages/components/src/components/CloseConnection.js
+++ b/packages/components/src/components/CloseConnection.js
@@ -58,39 +58,6 @@ print('WebSocket connection closed.');`
 };
 
 /**
- * Helper function to resolve config
- * @param {language} language 
- * @param {framework} framework 
- * @returns 
- */
-function resolveCloseConfig(language, framework = '') {
-  const config = websocketCloseConfig[language];
-  
-  if (!config) {
-    return { methodDocs: '', methodLogic: '' };
-  }
-  
-  // Handle flat structure (python, javascript, dart)
-  if (config.methodLogic || config.methodDocs) {
-    return {
-      methodDocs: config.methodDocs || '',
-      methodLogic: config.methodLogic || ''
-    };
-  }
-  
-  // Handle nested structure (java with framework)
-  if (framework && config[framework]) {
-    const frameworkConfig = config[framework];
-    return {
-      methodDocs: frameworkConfig.methodDocs || '',
-      methodLogic: frameworkConfig.methodLogic || ''
-    };
-  }
-  
-  return { methodDocs: '', methodLogic: '' };
-}
-
-/**
  * Renders a WebSocket close connection method with optional pre and post execution logic.
  *
  * @param {Object} props - Component props.
@@ -103,19 +70,14 @@ function resolveCloseConfig(language, framework = '') {
  * @param {number} props.indent=2 - Indentation level for the method block.
  * @returns {JSX.Element} Rendered method block with appropriate formatting.
  */
-export function CloseConnection({ language, framework = '', methodName = 'close', methodParams = [], preExecutionCode = '', postExecutionCode = '', indent = 2 }) {
-  const { methodDocs, methodLogic } = resolveCloseConfig(language, framework);
-  
+export function CloseConnection({ methodName = 'close', methodParams = [], indent = 2, ...props }) {
   return (
     <MethodGenerator
-      language={language}
+      methodConfig={websocketCloseConfig}
       methodName={methodName}
-      methodParams = {methodParams}
-      methodDocs = {methodDocs}
-      methodLogic = {methodLogic}
-      preExecutionCode = {preExecutionCode}
-      postExecutionCode = {postExecutionCode}
-      indent = {indent}
+      methodParams={methodParams}
+      indent={indent}
+      {...props}
     />
   );
 }

--- a/packages/components/src/components/RegisterErrorHandler.js
+++ b/packages/components/src/components/RegisterErrorHandler.js
@@ -42,24 +42,15 @@ else:
  * @param {Object} [props.customMethodConfig] - Optional overrides for default method configuration.
  * @returns {JSX.Element} Rendered method block with appropriate formatting.
  */
-export function RegisterErrorHandler({ language, methodName = 'registerErrorHandler', methodParams = [], preExecutionCode = '', postExecutionCode = '', customMethodConfig }) {
-  const {
-    methodDocs = '',
-    methodLogic = ''
-  } = websocketErrorRegisterConfig[language];
-
+export function RegisterErrorHandler({ methodName = 'registerErrorHandler', methodParams = [], ...props }) {
   return (
     <MethodGenerator
-      language={language}
+      methodConfig={websocketErrorRegisterConfig}
       methodName={methodName}
       methodParams={methodParams}
-      methodDocs={methodDocs}
-      methodLogic={methodLogic}
-      preExecutionCode={preExecutionCode}
-      postExecutionCode={postExecutionCode}
       indent={2}
       newLines={2}
-      customMethodConfig={customMethodConfig}
+      {...props}
     />
   );
 }

--- a/packages/components/src/components/RegisterMessageHandler.js
+++ b/packages/components/src/components/RegisterMessageHandler.js
@@ -41,23 +41,15 @@ else:
  * @param {string} props.postExecutionCode - Code to insert after the main function logic.
  * @returns {JSX.Element} Rendered method block with appropriate formatting.
  */
-export function RegisterMessageHandler({ language, methodName = 'registerMessageHandler', methodParams = [], preExecutionCode = '', postExecutionCode = '' }) {
-  const {
-    methodDocs = '',
-    methodLogic = ''
-  } = websocketMessageRegisterConfig[language];
-
+export function RegisterMessageHandler({ methodName = 'registerMessageHandler', methodParams = [], ...props }) {
   return (
     <MethodGenerator
-      language={language}
+      methodConfig={websocketMessageRegisterConfig}
       methodName={methodName}
       methodParams={methodParams}
-      methodDocs={methodDocs}
-      methodLogic={methodLogic}
-      preExecutionCode={preExecutionCode}
-      postExecutionCode={postExecutionCode}
       indent={2}
       newLines={2}
+      {...props}
     />
   );
 }


### PR DESCRIPTION
- `resolveCloseConfig` - is very generic and could work for any component, so I move it
- components config like for example `websocketCloseConfig` is no longer invoked inside component, but passed as prop to `MethodGenerator`. This was also pretty generic, so could be delegated to `MethodGenerator`
- since implementation is more generic, we can use `{...props}`